### PR TITLE
Handle postgres bools and use params in transact

### DIFF
--- a/src/lighthouse/core.clj
+++ b/src/lighthouse/core.clj
@@ -178,7 +178,8 @@
   (if (and (vector? val)
            (= 2 (count val))
            (= "boolean" (get-in schema [(first val) :db/type])))
-    [(first val) (= 1 (second val))]
+    [(first val) (or (true? (second val))
+                     (= 1 (second val)))]
     val))
 
 (defn q

--- a/src/lighthouse/core.clj
+++ b/src/lighthouse/core.clj
@@ -97,7 +97,7 @@
   ([conn query params]
    (let [schema (schema conn)
          db (db conn)
-         sql (sql/sql-vec db schema query {})]
+         sql (sql/sql-vec db schema query params)]
      (jdbc/execute! conn sql)))
   ([conn query]
    (transact conn query {})))


### PR DESCRIPTION
Currently any params to transact are ignored. This leads to getting an exception thrown when trying to do something like 

```clojure
(db/transact conn
               '[:update orders
                 :set    [orders/retrieved true]
                 :where  [orders/order-id ?oid]]
               {:oid order-id})
```

Also, postgres bools are not recognized. Any boolean values in a query result are false.

This pull request fixes them both. However I did not test with sqlite, so I might have broken something.
